### PR TITLE
Fix: prevent adding keys with undefined values to the yar object in lazy mode

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -149,8 +149,10 @@ internals.Yar = class {
         if (this._store._lazyKeys) {
             this._isLazy = true;                         // Default to lazy mode if previously set
             for (const key of this._store._lazyKeys) {
-                this[key] = this._store[key];
-                delete this._store[key];
+                if (key in this._store) {
+                    this[key] = this._store[key];
+                    delete this._store[key];
+                }
             }
         }
     }


### PR DESCRIPTION
This PR adds a check before copying stored keys to the `yar` object in lazy mode to prevent adding undefined values.

### Problem

In some cases the `yar.onPreAuth()` can be called several times in a row without any `yar.onPreResponse()` call in between. 

In `lazy` mode, this causes the properties moved from the internal `_store` to the `yar` object to be overridden with undefined values.

Example with a "authorize" lazy key:

1. first call to `onPreAuth`: "authorize" property is moved from the `_store` to the `yar` object in the `_initialize()`.
2. second call to `onPreAuth`: the "authorize" key is still the `_store._lazyKeys` so the code tries to move the "authorize" value from the store to the `yar` object. However this was already moved in (1), so this results in the "authorize" property on the `yar` object to be overridden with an "undefined" value.

### Solution

Only move the properties if they exist in the `_store`.

**Alternative solution**

Empty the `_lazyKeys` after moving the values in `_initialize()`. Note: deleting the `_lazyKeys` would result in the `lazy` mode to be reseted to false, so `_lazyKeys` needs to be set to `[]` instead of being deleted.